### PR TITLE
Support for multiple paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,16 +21,16 @@ exports.breakCache = function (src, matcher, config) {
 
     var opts = mergeOptions(_.cloneDeep(defaults), config);
 
-    function replacer(src, match) {
-        var replacement = _getReplacement(opts.replacement, opts);
+    function replacer(src, match, index) {
+        var replacement = _getReplacement(opts.replacement, opts, index);
         var replacer    = _getReplacer(opts.position, replacement);
         var regex       = _getRegex(match, opts.position);
         return src.replace(regex, replacer);
     }
 
     if (Array.isArray(matcher)) {
-        matcher.forEach(function (match) {
-            src = replacer(src, match);
+        matcher.forEach(function (match, index) {
+            src = replacer(src, match, index);
         });
     } else {
         return replacer(src, matcher);
@@ -42,9 +42,10 @@ exports.breakCache = function (src, matcher, config) {
 /**
  * @param {string|function} replacement
  * @param config
+ * @param {number} index (can be null/undefined)
  * @returns {*}
  */
-function _getReplacement(replacement, config) {
+function _getReplacement(replacement, config, index) {
 
     if (replacement === "time") {
         return new Date().getTime().toString();
@@ -55,7 +56,12 @@ function _getReplacement(replacement, config) {
             return md5(config.src, config.length || 10);
         } else {
             if (config.src.path) {
-                var content = getFileContents(config.src.path);
+                var content;
+                if (Array.isArray(config.src.path)) {
+                    content = getFileContents(config.src.path[index || 0]);
+                } else {
+                    content = getFileContents(config.src.path);
+                }
                 if (content) {
                     return md5(content, config.length || 10);
                 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cache-breaker",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Cache Breaking Tasks",
   "main": "index.js",
   "scripts": {

--- a/test/fixtures/dummy2.txt
+++ b/test/fixtures/dummy2.txt
@@ -1,0 +1,1 @@
+Additional Content From a dummy text file

--- a/test/specs/md5.src.multi.files.js
+++ b/test/specs/md5.src.multi.files.js
@@ -1,0 +1,85 @@
+var index = require('../../index');
+
+var assert = require('chai').assert;
+
+// HASH dummy.txt  = 2bd52f68d9
+// HASH dummy2.txt = 83135f90c4
+
+describe('Using multiple paths with md5 for creating the replacement', function () {
+
+    var config;
+    beforeEach(function () {
+        config = {
+            replacement: 'md5',
+            src: {
+                path: [
+                    __dirname + "/../fixtures/dummy.txt",
+                    __dirname + "/../fixtures/dummy2.txt"
+                ]
+            }
+        };
+    });
+
+    it('single ?rel', function () {
+
+        var test     = '<link href="/css/style.css" />';
+        var actual   = index.breakCache(test, 'style.css', config);
+
+        var expected = '<link href="/css/style.css?rel=2bd52f68d9" />';
+
+        assert.equal(actual, expected);
+    });
+    it('single filename', function () {
+
+        config.position = "filename";
+
+        var test     = '<link href="/css/style.css" />';
+        var actual   = index.breakCache(test, 'style.css', config);
+
+        var expected = '<link href="/css/style.2bd52f68d9.css" />';
+
+        assert.equal(actual, expected);
+    });
+    it('single overwrite', function () {
+
+        config.position = "overwrite";
+
+        var test     = '<link href="/css/style.r5432.css" />';
+        var actual   = index.breakCache(test, 'style.*.css', config);
+
+        var expected = '<link href="/css/style.2bd52f68d9.css" />';
+
+        assert.equal(actual, expected);
+    });
+    it('multiple files ?rel', function () {
+
+        var test     = '<link href="/css/style.css" /><link href="/css/style2.css" />';
+        var actual   = index.breakCache(test, ['style.css', 'style2.css'], config);
+
+        var expected = '<link href="/css/style.css?rel=2bd52f68d9" /><link href="/css/style2.css?rel=83135f90c4" />';
+
+        assert.equal(actual, expected);
+    });
+    it('multiple files filename', function () {
+
+        config.position = "filename";
+
+        var test     = '<link href="/css/style.css" /><link href="/css/style2.css" />';
+        var actual   = index.breakCache(test, ['style.css', 'style2.css'], config);
+
+        var expected = '<link href="/css/style.2bd52f68d9.css" /><link href="/css/style2.83135f90c4.css" />';
+
+        assert.equal(actual, expected);
+    });
+    it('multiple files overwrite', function () {
+
+        config.position = "overwrite";
+
+        var test     = '<link href="/css/style.r5432.css" /><link href="/css/style2.r5432.css" />';
+        var actual   = index.breakCache(test, ['style.*.css', 'style2.*.css'], config);
+
+        var expected = '<link href="/css/style.2bd52f68d9.css" /><link href="/css/style2.83135f90c4.css" />';
+
+        assert.equal(actual, expected);
+    });
+});


### PR DESCRIPTION
I wanted the ability to use your grunt plugin with multiple paths with different hashes. This change adds that support without affecting the original intent.

Config snippet:

``` javascript
var config = {
    match: [ 'style.css', 'style2.css' ],
    replacement: 'md5',
    src: {
        path: [
            __dirname + "/../fixtures/dummy.txt",
            __dirname + "/../fixtures/dummy2.txt"
        ]
    }
};
```
