### PR TITLE
Adds escaped double quotes to the regex

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,7 +74,7 @@ function _getReplacement(replacement, config) {
 function _getRegex(matcher, position) {
 
     function fullMatcher() {
-        return new RegExp("(('|\")(.+?)?)("+matcher+")([\\w\\?=]*)('|\")", "g");
+        return new RegExp("(('|\")(.+?)?)("+matcher+")([\\w\\?=]*)('|\"|\\\\\")", "g");
     }
 
     function prepareString(seg) {


### PR DESCRIPTION
I had to do that to have grunt-cache-breaker inserts the timestamp inside an already compiled dustjs template with backward slash escaped double quotes. Please feel free to merge it if you think it's an appropriate change. 
